### PR TITLE
Minor fixes.

### DIFF
--- a/drowsy_dromedary.rb
+++ b/drowsy_dromedary.rb
@@ -83,10 +83,12 @@ class DrowsyDromedary < Grape::API
 
     def process_data_recursively(data)
       data.keys.each do |k|
-        if data[k]["$date"]
-          data[k] = Time.parse data[k]["$date"]
-        elsif data[k].kind_of? Hash
-          process_data_recursively(data[k])
+        if data[k].kind_of? Hash
+          if data[k]["$date"]
+            data[k] = Time.parse data[k]["$date"]
+          else
+            process_data_recursively(data[k])
+          end
         end
       end
     end
@@ -119,7 +121,7 @@ class DrowsyDromedary < Grape::API
     if e.nil? || e == "" # why is e coming up empty?
       e = "Invalid ObjectID!"
     end
-    error_response({'message' => e, 'status' => 400})
+    error_response({:message => e, :status => 400})
   end
 
   get '/' do


### PR DESCRIPTION
The attached commit contains the following:
- Added cursory fix for handling for data[k]['$date']
- Added a minor fix for error_response, possibly addressing e being null?

Note that I am testing my work against ruby 1.8.7.  Without the first fix I was unable to process any dates in the following format:

{
  "now": {
    "$date": "2013-01-28T13:57:20.075Z"
  }
}

The second fix might help with e being null, though I am not sure if that's the specific problem you were seeing.  This fix comes from someone else on my team who noticed it and submitted it to me.

Note that this code fails the following two tests.  Also note that prior to this fix, it was failing these tests plus the "stores dates encoded as { $date: '...' } as ISODate".

Failures:

  1) DrowsyDromedary /db/collection /db/collection/id PUT can deal with JSON input containing arrays
     Failure/Error: foo['foo'][0].should == 1
       expected: 1
            got: "1" (using ==)
     # ./spec.rb:267

  2) DrowsyDromedary /db/collection /db/collection/id DELETE deletes an item from the collection
     Failure/Error: foo.should be_nil
       expected: nil
            got: #<BSON::OrderedHash:0x3f8716b15058 {"_id"=>BSON::ObjectId('510692604b5d940797000022'), "foo"=>"faa"}>
     # ./spec.rb:298

Finished in 0.46329 seconds
21 examples, 2 failures

Failed examples:

rspec ./spec.rb:257 # DrowsyDromedary /db/collection /db/collection/id PUT can deal with JSON input containing arrays
rspec ./spec.rb:291 # DrowsyDromedary /db/collection /db/collection/id DELETE deletes an item from the collection
